### PR TITLE
Goal - basic menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ OUT_NAME = test
 
 SOURCES = $(wildcard $(SRC_DIR)/*.c)
 
+# TODO : Add full support for MSVC (still requires some tweaks)
+
 cc_is_gcc_or_clang = false
 cc_is_msvc = false
 ifeq ($(CC),gcc)

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ SOURCES = $(wildcard $(SRC_DIR)/*.c)
 
 # Produce temp files XOR Compile
 
-DEBUG_OPTS   = -I. -std=c23 -Wall -Wextra -DDEBUG -O0 -g3 -fsanitize=address,leak,undefined
-RELEASE_OPTS = -I. -std=c23 -Wall -Wextra -Werror -O3
+DEBUG_OPTS   = -I. -std=c2x -Wall -Wextra -DDEBUG -O0 -g3
+RELEASE_OPTS = -I. -std=c2x -Wall -Wextra -Werror -O3
+
+ifneq ($(OS),Windows_NT)
+	DEBUG_OPTS   += -fsanitize=address,leak,undefined
+endif
 
 TMP_OPTS     =
 ifeq ($(tmp),true)

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ endif
 # https://stackoverflow.com/questions/20763629/test-whether-a-directory-exists-inside-a-makefile
 
 debug: | $(BUILD_DIR)
-	cd build && $(CC) ../$(SOURCES) $(DEBUG_OPTS) $(TMP_OPTS)
+	cd build && $(CC) $(addprefix ../, $(SOURCES)) $(DEBUG_OPTS) $(TMP_OPTS)
 
 release: | $(BUILD_DIR)
-	cd build && $(CC) ../$(SOURCES) $(RELEASE_OPTS) $(TMP_OPTS)
+	cd build && $(CC) $(addprefix ../, $(SOURCES)) $(RELEASE_OPTS) $(TMP_OPTS)
 
 clean:
 ifeq ($(shell test -d $(BUILD_DIR) && echo 1 || echo 0), 1)

--- a/Makefile
+++ b/Makefile
@@ -6,30 +6,53 @@ OUT_NAME = test
 
 SOURCES = $(wildcard $(SRC_DIR)/*.c)
 
-
-# Produce temp files XOR Compile
-
-DEBUG_OPTS   = -I. -std=c2x -Wall -Wextra -DDEBUG -O0 -g3
-RELEASE_OPTS = -I. -std=c2x -Wall -Wextra -Werror -O3
-
-ifneq ($(OS),Windows_NT)
-	DEBUG_OPTS   += -fsanitize=address,leak,undefined
+cc_is_gcc_or_clang = false
+cc_is_msvc = false
+ifeq ($(CC),gcc)
+	cc_is_gcc_or_clang = true
+else ifeq ($(CC),clang)
+	cc_is_gcc_or_clang = true
+else ifeq ($(CC),cl)
+	cc_is_msvc = true
+else ifeq ($(CC),cl.exe)
+	cc_is_msvc = true
 endif
 
+DEBUG_OPTS   =
+RELEASE_OPTS =
+ifeq ($(cc_is_gcc_or_clang),true)
+	DEBUG_OPTS   = -I. -std=c2x -Wall -Wextra -DDEBUG -O0 -g3
+	RELEASE_OPTS = -I. -std=c2x -Wall -Wextra -Werror -O2
+else ifeq ($(cc_is_msvc),true)
+	DEBUG_OPTS   = -std:clatest -Wall -DDEBUG -Od -ZI
+	RELEASE_OPTS = -std:clatest -Wall -WX -O2
+endif
+
+ifneq ($(OS),Windows_NT)
+	DEBUG_OPTS += -fsanitize=address,leak,undefined
+endif
+
+# Produce temp files XOR Compile
 TMP_OPTS     =
 ifeq ($(tmp),true)
-	TMP_OPTS += -S -fverbose-asm -save-temps -w
-	ifeq ($(CC), gcc)
-		TMP_OPTS += -fdump-tree-optimized
-	else ifeq ($(CC), clang)
-	# Disables asm output as the -S flag produces textual IR when combined with -emit-llvm
-	# See https://releases.llvm.org/7.0.0/tools/clang/docs/Toolchain.html
-	# Uncomment the line below if you want to generate LLVM IR instead of assembly when using clang.
-	#	TMP_OPTS += -emit-llvm
+	ifeq ($(cc_is_gcc_or_clang),true)
+		TMP_OPTS += -S -fverbose-asm -save-temps -w
+		ifeq ($(CC), gcc)
+			TMP_OPTS += -fdump-tree-optimized
+		else ifeq ($(CC), clang)
+		# Disables asm output as the -S flag produces textual IR when combined with -emit-llvm
+		# See https://releases.llvm.org/7.0.0/tools/clang/docs/Toolchain.html
+		# Uncomment the line below if you want to generate LLVM IR instead of assembly when using clang.
+		#	TMP_OPTS += -emit-llvm
+		endif
+	else ifeq ($(cc_is_msvc),true)
+		TMP_OPTS += -P -Fi
 	endif
 else
-	DEBUG_OPTS   += -o $(OUT_NAME)
-	RELEASE_OPTS += -o $(OUT_NAME)
+	ifeq ($(cc_is_gcc_or_clang),true)
+		DEBUG_OPTS   += -o $(OUT_NAME)
+		RELEASE_OPTS += -o $(OUT_NAME)
+	endif
 endif
 
 # Thanks to :

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Escape Lib
+
+Local repository for now.
+
+TODO : Add project description.
+
+## Developpement scheme
+The project will use the `feature` / `bugfix` / `test` convetion for branch names but adds another one called "goal".
+Branch named `goal/something` will contain a few commits setting up a test file which will do something that should be easily achievable using the library but that is not yet implemented. Quick example :
+```C
+void cool_test() {
+    printf(
+        "\x1b[?1049h\x1b[H"
+        "\x1b[3mThe excitement of creating something new and hopefully useful flows down your veins\n"
+        "as you prepare for the very first commit.\x1b[23m\n\n\n\n"
+        "\x1b[1;33m		You are filled with determination.\x1b[m");
+    getchar();
+    printf("\x1b[?1049l");
+}
+```
+Such a test could be written in a `goal/style-handling` branch so that other branches, let's say `feature/color-handling` and `feature/style-handling` can be open after the "goal" branch has been merged. This will help focus developpement into the implementation of actual features instead of trying to implement everything without a clear direction.
+
+The above example could then become :
+```C
+void cool_test() {
+    altbuf_visbile(true);
+    cursor_visible(false);
+
+    print_styled_wrapped("The excitement of creating something new and hopefully useful flows down your veins as you prepare for the very first commit.", 85, ITALIC);
+    move_relative(5, 8);
+    print_styled("You are filled with determination.", RED, BOLD);
+
+    getchar();
+    altbuf_visbile(false);
+    cursor_visible(true);
+}
+```
+
+In the next branches.
+(Of course the latter is horrible but you get the point).
+

--- a/src/test.c
+++ b/src/test.c
@@ -1,13 +1,70 @@
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <termios.h>
 
-int main() {
-	// On Saturday, the 19th of April 2025.
-	printf(
-		"\x1b[?1049h\x1b[H"
-		"\x1b[3mThe excitement of creating something new and hopefully useful flows down your veins\n"
-		"as you prepare for the very first commit.\x1b[23m\n\n\n\n"
-		"\x1b[1;33m		You are filled with determination.\x1b[m");
+#define max(x, y) x <= y ? x : y
+
+enum horiz_margin_of_err : bool {
+	LEFT, RIGHT
+};
+enum virt_margin_of_err : bool {
+	TOP, BOTTOM
+};
+#define HORIZ_MARGIN_OF_ERR_ALIGN LEFT
+#define VIRT_MARGIN_OF_ERR_ALIGN BOTTOM
+
+int main(int argc, char **argv) {
+	printf("\x1b[?1049h"); // Shows alternate buffer
+	printf("\x1b[?25l"); // Hides the cursor
+
+	struct termios term_attr;
+	tcgetattr(STDIN_FILENO, &term_attr);
+	term_attr.c_lflag &= ~ECHO;
+	tcsetattr(STDIN_FILENO, 0, &term_attr);
+
+	struct winsize window;
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &window); // Get the window width and height in cells (columns, lines) and in pixels
+
+	// Paint half the cells (for visualization purposes)
+	for (int i = 0; i < window.ws_row * window.ws_col; ++i) {
+		printf(i % 2 == 0 ? "\x1b[48;5;232m \x1b[m" : " ");
+	}
+	printf("\x1b[H"); // move cursor to home position
+
+	printf("cols : %hu, rows: %hu\n", window.ws_col, window.ws_row);
+
+	const char* label = (argc == 1 ? "Hello, World!" : argv[1]);
+	const int label_len = strlen(label);
+
+	// When the parity of the label's length and the number of columns isn't the same, a slight offset will be produced
+	// either left or right, due to the nature of the integer division.
+	// We look for it and check if the HORIZ_MARGIN_OF_ERR_ALIGN property is opposite to the offset
+	// We can the apply a correction of + 1 or - 1 to match the desired off-centered alignment
+	unsigned short left_gap_len = (window.ws_col / 2) - (label_len / 2); 
+	const unsigned short right_gap_len = window.ws_col - (left_gap_len + label_len);
+	const char align_error = left_gap_len - right_gap_len; // -1 if left-centered, 1 if right-centered, 0 if perfectly centered
+	if (align_error == -1 && HORIZ_MARGIN_OF_ERR_ALIGN == RIGHT) {
+		left_gap_len += 1;
+	} else if (align_error == 1 && HORIZ_MARGIN_OF_ERR_ALIGN == LEFT) {
+		left_gap_len -= 1;
+	}
+
+	const unsigned short virt_margin_of_error = ((window.ws_row % 2) != 0 ? 1 : VIRT_MARGIN_OF_ERR_ALIGN);
+	const unsigned short middle_line = window.ws_row / 2 + virt_margin_of_error;
+
+	printf("\x1b[%hu;%huH", middle_line, left_gap_len + 1); // We go to y, x (line, column)
+	for (int i = 0; i < label_len; ++i) {
+		uint8_t val = max(232 + ((float)i / label_len) * 24, 255); // 8 bit color ID
+		printf("\x1b[38;5;%hhu;1;3m%c\x1b[m", val, label[i]); // Bold, italic and grayscaled gradient colored
+	}
+
 	getchar();
-	printf("\x1b[?1049l");
+	printf("\x1b[?1049l"); // Hides the alternate buffer
+	printf("\x1b[?25h"); // Shows the cursor
+	term_attr.c_lflag |= ECHO;
+	tcsetattr(STDIN_FILENO, 0, &term_attr);
 }
 

--- a/src/test.c
+++ b/src/test.c
@@ -5,7 +5,7 @@
 
 #if _WIN32
 #include <windows.h>
-#elif __linux__
+#elif __unix__
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <termios.h>
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 	// Just in case?
 	SetConsoleMode(h_out, original_out_mode);
 	SetConsoleMode(h_in, original_in_mode);
-#elif __linux__
+#elif __unix__
 	term_attr.c_lflag |= ECHO;
 	tcsetattr(STDIN_FILENO, 0, &term_attr);
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 	GetConsoleMode(h_out, &original_out_mode);
 
 	SetConsoleMode(h_out, original_out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-	SetConsoleMode(h_in, original_in_mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+	SetConsoleMode(h_in, (original_in_mode | ENABLE_VIRTUAL_TERMINAL_INPUT) & (~ENABLE_ECHO_INPUT));
 
 	CONSOLE_SCREEN_BUFFER_INFO buf_info;
 	GetConsoleScreenBufferInfo(h_out, &buf_info);

--- a/src/test.c
+++ b/src/test.c
@@ -1,25 +1,40 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
+
+#if _WIN32
+#include <stdlib.h>
+#include <windows.h>
+#elif __linux__
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <termios.h>
+#endif
 
+#if !(_WIN32)
 #define max(x, y) x <= y ? x : y
+#endif
 
-enum horiz_margin_of_err : bool {
-	LEFT, RIGHT
-};
-enum virt_margin_of_err : bool {
-	TOP, BOTTOM
-};
-#define HORIZ_MARGIN_OF_ERR_ALIGN LEFT
-#define VIRT_MARGIN_OF_ERR_ALIGN BOTTOM
+#define LEFT  0
+#define RIGHT 1
+
+#define TOP    0
+#define BOTTOM 1
+
+const bool HORIZ_MARGIN_OF_ERR_ALIGN = LEFT;
+const bool VIRT_MARGIN_OF_ERR_ALIGN  = BOTTOM;
 
 int main(int argc, char **argv) {
-	printf("\x1b[?1049h"); // Shows alternate buffer
-	printf("\x1b[?25l"); // Hides the cursor
+	unsigned short cols, rows;
 
+#if _WIN32
+	system("");
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
+	cols = info.dwMaximumWindowSize.X;
+	rows = info.dwMaximumWindowSize.Y;
+#else
 	struct termios term_attr;
 	tcgetattr(STDIN_FILENO, &term_attr);
 	term_attr.c_lflag &= ~ECHO;
@@ -27,14 +42,20 @@ int main(int argc, char **argv) {
 
 	struct winsize window;
 	ioctl(STDOUT_FILENO, TIOCGWINSZ, &window); // Get the window width and height in cells (columns, lines) and in pixels
+	cols = window.ws_col;
+	rows = window.ws_row;
+#endif
+
+	printf("\x1b[?1049h"); // Shows alternate buffer
+	printf("\x1b[?25l"); // Hides the cursor
 
 	// Paint half the cells (for visualization purposes)
-	for (int i = 0; i < window.ws_row * window.ws_col; ++i) {
+	for (int i = 0; i < rows * cols; ++i) {
 		printf(i % 2 == 0 ? "\x1b[48;5;232m \x1b[m" : " ");
 	}
 	printf("\x1b[H"); // move cursor to home position
 
-	printf("cols : %hu, rows: %hu\n", window.ws_col, window.ws_row);
+	printf("cols : %hu, rows: %hu\n", cols, rows);
 
 	const char* label = (argc == 1 ? "Hello, World!" : argv[1]);
 	const int label_len = strlen(label);
@@ -43,17 +64,19 @@ int main(int argc, char **argv) {
 	// either left or right, due to the nature of the integer division.
 	// We look for it and check if the HORIZ_MARGIN_OF_ERR_ALIGN property is opposite to the offset
 	// We can the apply a correction of + 1 or - 1 to match the desired off-centered alignment
-	unsigned short left_gap_len = (window.ws_col / 2) - (label_len / 2); 
-	const unsigned short right_gap_len = window.ws_col - (left_gap_len + label_len);
+	unsigned short left_gap_len = (cols / 2) - (label_len / 2); 
+	const unsigned short right_gap_len = cols - (left_gap_len + label_len);
+	
 	const char align_error = left_gap_len - right_gap_len; // -1 if left-centered, 1 if right-centered, 0 if perfectly centered
+
 	if (align_error == -1 && HORIZ_MARGIN_OF_ERR_ALIGN == RIGHT) {
 		left_gap_len += 1;
 	} else if (align_error == 1 && HORIZ_MARGIN_OF_ERR_ALIGN == LEFT) {
 		left_gap_len -= 1;
 	}
 
-	const unsigned short virt_margin_of_error = ((window.ws_row % 2) != 0 ? 1 : VIRT_MARGIN_OF_ERR_ALIGN);
-	const unsigned short middle_line = window.ws_row / 2 + virt_margin_of_error;
+	const unsigned short virt_margin_of_error = ((rows % 2) != 0 ? 1 : VIRT_MARGIN_OF_ERR_ALIGN);
+	const unsigned short middle_line = rows / 2 + virt_margin_of_error;
 
 	printf("\x1b[%hu;%huH", middle_line, left_gap_len + 1); // We go to y, x (line, column)
 	for (int i = 0; i < label_len; ++i) {
@@ -64,7 +87,9 @@ int main(int argc, char **argv) {
 	getchar();
 	printf("\x1b[?1049l"); // Hides the alternate buffer
 	printf("\x1b[?25h"); // Shows the cursor
+#if __linux__
 	term_attr.c_lflag |= ECHO;
 	tcsetattr(STDIN_FILENO, 0, &term_attr);
+#endif
 }
 

--- a/src/test.c
+++ b/src/test.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 	GetConsoleMode(h_out, &original_out_mode);
 
 	SetConsoleMode(h_out, original_out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-	SetConsoleMode(h_in, (original_in_mode | ENABLE_VIRTUAL_TERMINAL_INPUT) & (~ENABLE_ECHO_INPUT));
+	SetConsoleMode(h_in, original_in_mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
 
 	CONSOLE_SCREEN_BUFFER_INFO buf_info;
 	GetConsoleScreenBufferInfo(h_out, &buf_info);


### PR DESCRIPTION
Adds basic TUI elements such as colored labels, a background checkerboard pattern and most importantly a way to control text alignment when perfect centering is not possible, e.g. when the text's length is odd and the terminal's width isn't, or vice versa. 
The result of the integer divison of these two would result in an unpredictable alignment, one cell off the right or one off the left. For now, the program actually counts the number of cells on each side to check if they meet the desired off-centered alignment (left or right), but there must be a simpler way to do so. This a goal branch however, optimizations and overall code readability are not the main concerns (see README).

**NOTE** : `The README has been created and the Makefile improved, yet it doesn't fully supporting all platforms (mainly Windows with the MSVC toolchain)).`

> Tested on Linux, FreeBSD and Windows 10 (Mac should work too).