### PR TITLE
Feature : init/cleanup handling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
-Language: C
 BasedOnStyle: LLVM
 
 UseTab: ForIndentation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Such a test could be written in a `goal/style-handling` branch so that other bra
 
 The above example could then become :
 ```C
-void cool_test() {
+void cool_test()
+{
     altbuf_visbile(true);
     cursor_visible(false);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -38,7 +38,7 @@ void init_term()
 	SetConsoleMode(h_stdout, og_stdout_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 
 	const DWORD new_in_mode = og_stdin_mode | ENABLE_VIRTUAL_TERMINAL_INPUT;
-	current_stdin_mode         = new_in_mode;
+	current_stdin_mode      = new_in_mode;
 	SetConsoleMode(h_stdin, new_in_mode);
 
 	og_output_cp = GetConsoleOutputCP();
@@ -65,8 +65,8 @@ int set_termflags(const FLAG_T flags)
 	 * TODO : some "side effects" are caused by the combination of those two flags, (presumably
 	 * something that has to do with line buffering) and should be studied with more care. */
 	SetConsoleMode(h_stdin, current_stdin_mode & (flags & NO_ECHO)
-	                         ? (~ENABLE_ECHO_INPUT)
-	                         : (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
+	                            ? (~ENABLE_ECHO_INPUT)
+	                            : (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
 #endif
 
 	printf(CSI "?1049%c", flags & ALTBUF ? 'h' : 'l');

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1,0 +1,108 @@
+#if _WIN32
+#include <windows.h>
+#elif __unix__
+#include <termios.h>
+#include <unistd.h>
+#endif
+#include <stdio.h>
+
+#include "terminal.h"
+
+// Control Sequence Introducer
+#define CSI "\x1b["
+
+#if __unix__
+static struct termios current_term_attr;
+#elif _WIN32
+static HANDLE h_stdin;
+static HANDLE h_stdout;
+static DWORD current_stdin_mode;
+static DWORD og_stdin_mode;
+static DWORD og_stdout_mode;
+static UINT og_output_cp;
+#endif
+
+static FLAG_T current_flags = 0;
+
+void init_term()
+{
+#if __unix__
+	tcgetattr(STDIN_FILENO, &current_term_attr);
+#elif _WIN32
+	h_stdin  = GetStdHandle(STD_INPUT_HANDLE);
+	h_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+
+	GetConsoleMode(h_stdout, &og_stdout_mode);
+	GetConsoleMode(h_stdin, &og_stdin_mode);
+
+	SetConsoleMode(h_stdout, og_stdout_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+	const DWORD new_in_mode = og_stdin_mode | ENABLE_VIRTUAL_TERMINAL_INPUT;
+	current_stdin_mode         = new_in_mode;
+	SetConsoleMode(h_stdin, new_in_mode);
+
+	og_output_cp = GetConsoleOutputCP();
+#endif
+
+	// TODO : gather termcaps but without termcap/terminfo
+	// Read this : https://lobste.rs/s/m1j4b4/terminfo_at_this_point_time_is_net
+}
+
+int set_termflags(const FLAG_T flags)
+{
+	if (flags == current_flags) {
+		return -1;
+	}
+
+#if __unix__
+	current_term_attr.c_lflag = (flags & NO_ECHO) ? current_term_attr.c_lflag & (~ECHO)
+	                                              : current_term_attr.c_lflag | ECHO;
+	tcsetattr(STDIN_FILENO, 0, &current_term_attr);
+#elif _WIN32
+	/* "This mode [`ENABLE_ECHO_INPUT`] can be used only if the ENABLE_LINE_INPUT mode is also
+	 * enabled."
+	 * - https://learn.microsoft.com/en-us/windows/console/setconsolemode
+	 * TODO : some "side effects" are caused by the combination of those two flags, (presumably
+	 * something that has to do with line buffering) and should be studied with more care. */
+	SetConsoleMode(h_stdin, current_stdin_mode & (flags & NO_ECHO)
+	                         ? (~ENABLE_ECHO_INPUT)
+	                         : (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
+#endif
+
+	printf(CSI "?1049%c", flags & ALTBUF ? 'h' : 'l');
+	printf(CSI "?25%c", flags & HIDE_CURSOR ? 'l' : 'h');
+
+	current_flags = flags;
+	return 0;
+}
+
+
+const FLAG_T* get_termflags()
+{
+	return &current_flags;
+}
+
+#if _WIN32
+const HANDLE* get_g_stdin_hndl()
+{
+	return &h_stdin;
+}
+
+const HANDLE* get_g_stdout_hndl()
+{
+	return &h_stdout;
+}
+#endif
+
+
+void cleanup_term()
+{
+	set_termflags(0);
+
+#if _WIN32
+	SetConsoleOutputCP(og_output_cp);
+	SetConsoleMode(h_stdout, og_stdout_mode);
+	SetConsoleMode(h_stdin, og_stdin_mode);
+#endif
+}
+

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+// Avoids replacing the type everywhere when required
+#define FLAG_T unsigned int
+
+
+enum termflags : FLAG_T {
+	ALTBUF      = 0x1,
+	HIDE_CURSOR = 0x2,
+	NO_ECHO     = 0x4,
+};
+
+/* Initialize some states variables and gathers information about the terminal the program is running in.
+ * Required for escape sequences to work properly. */
+void init_term();
+
+/* Sets the given terminal flags via bitmask.
+ * Available flags are available int `enum termflags`.
+ * Returns 0 if flags were applied, -1 if it was the same as before. */
+int set_termflags(const FLAG_T flags);
+
+/* Returns a pointer to the program's static terminal flags. */
+const FLAG_T* get_termflags();
+
+#if _WIN32
+/* Same as `GetStdHandle(STD_IN_HANDLE)`, but returns a pointer
+ * to the already statically stored result of this exact call used internally. */
+const HANDLE* get_g_stdin_hndl();
+/* Same as `GetStdHandle(STD_OUT_HANDLE)`, but returns a pointer
+ * to the already statically stored result of this exact call used internally. */
+const HANDLE* get_g_stdout_hndl();
+#endif
+
+/* Resets the terminal with none of the flags present in `enum termflags`. */
+void cleanup_term();
+

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -14,8 +14,8 @@ enum termflags : FLAG_T {
 	NO_ECHO     = 0x4,
 };
 
-/* Initialize some states variables and gathers information about the terminal the program is running in.
- * Required for escape sequences to work properly. */
+/* Initialize some states variables and gathers information about the terminal the program is
+ * running in. Required for escape sequences to work properly. */
 void init_term();
 
 /* Sets the given terminal flags via bitmask.

--- a/src/test.c
+++ b/src/test.c
@@ -1,21 +1,20 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdbool.h>
 #if _WIN32
 #include <windows.h>
 #elif __unix__
 #include <sys/ioctl.h>
-#include <unistd.h>
 #include <termios.h>
+#include <unistd.h>
 #endif
 
 #if !(_WIN32)
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
-// https://stackoverflow.com/questions/8292852/the-best-way-to-define-a-between-macro-in-c
-#define between(x, x_min, x_max) ((x) > (x_min) && (x) < (x_max))
+#define between(x, min, max) ((x) > (min) && (x) < (max))
 
 
 #define LEFT  0
@@ -28,25 +27,33 @@ const bool HORIZ_MARGIN_OF_ERR_ALIGN = LEFT;
 const bool VIRT_MARGIN_OF_ERR_ALIGN  = BOTTOM;
 
 
-typedef enum: char {
-	CONTINUATION, ASCII, DOUBLE_BEGIN, TRIPLE_BEGIN, QUADRUPLE_BEGIN, INVALID = -1,
+typedef enum : char {
+	INVALID = -1,
+	CONTINUATION,
+	ASCII,
+	DOUBLE_BEGIN,
+	TRIPLE_BEGIN,
+	QUADRUPLE_BEGIN
 } utf8_char_type;
 
 
-utf8_char_type get_utf8_char_type(const unsigned char c) {
-	if (c < 0x7F)                    return ASCII;
+utf8_char_type get_utf8_char_type(const unsigned char c)
+{
+	if (c < 0x7F) return ASCII;
 	else if (between(c, 0x80, 0xBF)) return CONTINUATION;
 	else if (between(c, 0xC0, 0xDF)) return DOUBLE_BEGIN;
 	else if (between(c, 0xE0, 0xEF)) return TRIPLE_BEGIN;
 	else if (between(c, 0xF0, 0xF7)) return QUADRUPLE_BEGIN; // Unlikely but defined by utf8
-	else                             return INVALID;
+	else return INVALID;
 }
 
-size_t utf8_strlen(const char* str, const size_t str_len) {
+size_t utf8_strlen(const char* str, const size_t str_len)
+{
 	size_t len = 0;
 
 	utf8_char_type uchar_i_type = INVALID;
-	size_t i = 0;
+	size_t i                    = 0;
+
 	while (i < str_len) {
 		uchar_i_type = get_utf8_char_type(str[i]);
 		if (uchar_i_type == INVALID) {
@@ -62,11 +69,13 @@ size_t utf8_strlen(const char* str, const size_t str_len) {
 
 // utf8_char_type get_char_type
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
 	unsigned short cols, rows;
 
 #if _WIN32
-	HANDLE h_in = GetStdHandle(STD_INPUT_HANDLE);
+
+	HANDLE h_in  = GetStdHandle(STD_INPUT_HANDLE);
 	HANDLE h_out = GetStdHandle(STD_OUTPUT_HANDLE);
 
 	DWORD original_in_mode;
@@ -86,19 +95,22 @@ int main(int argc, char **argv) {
 	SetConsoleOutputCP(CP_UTF8);
 
 #else
+
 	struct termios term_attr;
 	tcgetattr(STDIN_FILENO, &term_attr);
 	term_attr.c_lflag &= ~ECHO;
 	tcsetattr(STDIN_FILENO, 0, &term_attr);
 
 	struct winsize window;
-	ioctl(STDOUT_FILENO, TIOCGWINSZ, &window); // Get the window width and height in cells (columns, lines) and in pixels
+	ioctl(STDOUT_FILENO, TIOCGWINSZ,
+	      &window); // Get the window width and height in cells (columns, lines) and in pixels
 	cols = window.ws_col;
 	rows = window.ws_row;
+
 #endif
 
 	printf("\x1b[?1049h"); // Shows alternate buffer
-	printf("\x1b[?25l"); // Hides the cursor
+	printf("\x1b[?25l");   // Hides the cursor
 
 	// Paint half the cells (for visualization purposes)
 	for (int i = 0; i < rows * cols; ++i) {
@@ -108,24 +120,26 @@ int main(int argc, char **argv) {
 
 	printf("cols : %hu, rows: %hu\n", cols, rows);
 
-	/* NOTE : utf8 commandline argument on Windows requires powershell/cmd.exe to use the 65001 code page,
-	 * which needs to be set before the program is executed, obviously, but it is not the default,
-	 * so parsing argument with characters outside the ASCII range will lead to some weird bugs.
-	 * Interesting stack overflow post on the subject :
-	 * https://stackoverflow.com/questions/57131654/using-utf-8-encoding-chcp-65001-in-command-prompt-windows-powershell-window */
-	const char* label = (argc == 1 ? "Всем привет !" : argv[1]);
+	/* NOTE : utf8 commandline argument on Windows requires powershell/cmd.exe to use the 65001 code
+	 * page, which needs to be set before the program is executed, obviously, but it is not the
+	 * default, so parsing argument with characters outside the ASCII range will lead to some weird
+	 * bugs. Interesting stack overflow post on the subject :
+	 * https://stackoverflow.com/questions/57131654/using-utf-8-encoding-chcp-65001-in-command-prompt-windows-powershell-window
+	 */
+	const char* label                 = (argc == 1 ? "Всем привет !" : argv[1]);
 	const size_t label_code_point_len = strlen(label);
-	const int label_code_unit_len = utf8_strlen(label, label_code_point_len);
+	const int label_code_unit_len     = utf8_strlen(label, label_code_point_len);
 
-	// When the parity of the label's length and the number of columns isn't the same, a slight offset will be produced
-	// either left or right, due to the nature of the integer division.
-	// We look for it and check if the HORIZ_MARGIN_OF_ERR_ALIGN property is opposite to the offset
-	// We can the apply a correction of + 1 or - 1 to match the desired off-centered alignment
-	
-	unsigned short left_gap_len = (cols / 2) - (label_code_unit_len / 2); 
+	// When the parity of the label's length and the number of columns isn't the same, a slight
+	// offset will be produced either left or right, due to the nature of the integer division. We
+	// look for it and check if the HORIZ_MARGIN_OF_ERR_ALIGN property is opposite to the offset We
+	// can the apply a correction of + 1 or - 1 to match the desired off-centered alignment
+
+	const unsigned short left_gap_len        = (cols / 2) - (label_code_unit_len / 2);
 	const unsigned short right_gap_len = cols - (left_gap_len + label_code_unit_len);
-	
-	const char align_error = left_gap_len - right_gap_len; // -1 if left-centered, 1 if right-centered, 0 if perfectly centered
+
+	// -1 if left-centered, 1 if right-centered, 0 if perfectly centered
+	const char align_error = left_gap_len - right_gap_len;
 
 	if (align_error == -1 && HORIZ_MARGIN_OF_ERR_ALIGN == RIGHT) {
 		left_gap_len += 1;
@@ -134,28 +148,30 @@ int main(int argc, char **argv) {
 	}
 
 	const unsigned short virt_margin_of_error = ((rows % 2) != 0 ? 1 : VIRT_MARGIN_OF_ERR_ALIGN);
-	const unsigned short middle_line = rows / 2 + virt_margin_of_error;
+	const unsigned short middle_line          = rows / 2 + virt_margin_of_error;
 
 	printf("\x1b[%hu;%huH", middle_line, left_gap_len + 1); // We go to y, x (line, column)
 
 
 	utf8_char_type uchar_i_type = INVALID;
-	uint8_t val = 0;
+	uint8_t val                 = 0;
 	size_t code_point_i = 0, code_unit_i = 0;
 
 	while (code_point_i < label_code_point_len) {
 		val = min(232 + ((float)code_unit_i / label_code_unit_len) * 24, 255); // 8 bit color ID
 		const unsigned char uchar_i = label[code_point_i];
-		uchar_i_type = get_utf8_char_type(uchar_i);
-		
+		uchar_i_type                = get_utf8_char_type(uchar_i);
+
 		if (uchar_i_type == INVALID) {
 			return -1;
 		} else {
 			if (code_point_i > 0) {
 				printf("\x1b[m"); // End the sequence
 			}
-			printf("\x1b[38;5;%hhu;1;3m%c", val, uchar_i); // Begins the sequence : Bold, italic and grayscaled gradient colored
-			printf("%.*s", uchar_i_type - 1, label + code_point_i + 1); // prints the next continuation chars (if any)
+			printf("\x1b[38;5;%hhu;1;3m%c", val,
+			       uchar_i); // Begins the sequence : Bold, italic and grayscaled gradient colored
+			printf("%.*s", uchar_i_type - 1,
+			       label + code_point_i + 1); // prints the next continuation chars (if any)
 
 			++code_unit_i;
 			code_point_i += uchar_i_type;
@@ -164,15 +180,20 @@ int main(int argc, char **argv) {
 
 	getchar();
 	printf("\x1b[?1049l"); // Hides the alternate buffer
-	printf("\x1b[?25h"); // Shows the cursor
+	printf("\x1b[?25h");   // Shows the cursor
+
 #if _WIN32
+
 	SetConsoleOutputCP(original_output_cp);
 	// Just in case?
 	SetConsoleMode(h_out, original_out_mode);
 	SetConsoleMode(h_in, original_in_mode);
+
 #elif __unix__
+
 	term_attr.c_lflag |= ECHO;
 	tcsetattr(STDIN_FILENO, 0, &term_attr);
+
 #endif
 }
 

--- a/src/test.c
+++ b/src/test.c
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
 	// look for it and check if the HORIZ_MARGIN_OF_ERR_ALIGN property is opposite to the offset We
 	// can the apply a correction of + 1 or - 1 to match the desired off-centered alignment
 
-	const unsigned short left_gap_len        = (cols / 2) - (label_code_unit_len / 2);
+	unsigned short left_gap_len        = (cols / 2) - (label_code_unit_len / 2);
 	const unsigned short right_gap_len = cols - (left_gap_len + label_code_unit_len);
 
 	// -1 if left-centered, 1 if right-centered, 0 if perfectly centered


### PR DESCRIPTION
Introduces a basic lifecycle management through bitflags.
Some additional fieds are tracked on Windows due to other attributes needing to be reset in the end.

*From commit* [c2acf8bd136c03b722142345b1af854d3dbf715e](https://github.com/Souleymeine/escape-lib/commit/c2acf8bd136c03b722142345b1af854d3dbf715e) :

"Termflags allow the user to abstract driver level (tty/Console) and
terminal emulator level "options" or "settings" that will affect the
user experience overall.
On startup, `init_term` is called to initialize some static fields.
`set_termflags` takes a bitmask and writes control sequences or makes
syscalls to set tty/Console flags.
Some getter functions are provided to get some of the program's static
state variable. These vary depending on the OS type (unix | Windows,
basically).
`cleanup_term` restores the state of what a "sane" terminal should look
like (visible cursor, on the normal buffer, and with echo input).

Hopefully the code does the bare minimum it needs and is not
"pessimized" nor has any overhead compared to calling the raw
syscalls/writing control sequences."