### PR TITLE
Feature : utf8 grapheme detection

### DIFF
--- a/src/grapheme.c
+++ b/src/grapheme.c
@@ -1,0 +1,41 @@
+#include <stdbit.h>
+#include <stddef.h>
+
+#include "grapheme.h"
+
+enum cpt_type get_cpt_type(const unsigned char c)
+{
+	// https://www.rfc-editor.org/rfc/rfc3629#section-3
+	if (stdc_bit_width_uc(c) < 8) {
+		return ASCII;
+	} else {
+		const unsigned char leading_ones = stdc_leading_ones_uc(c);
+		// Check if there's a zero after leading one(s)
+		if (stdc_first_leading_zero_uc(c) == (unsigned char)(leading_ones + 1)) {
+			return leading_ones;
+		}
+	}
+
+	return INVALID;
+}
+
+int count_graphemes(const char* restrict str, const size_t str_len)
+{
+	unsigned int len = 0;
+
+	enum cpt_type i_type = INVALID;
+	size_t i             = 0;
+	while (i < str_len) {
+		i_type = get_cpt_type(str[i]);
+
+		if (i_type == INVALID) {
+			return -1;
+		} else {
+			++len;
+			i += i_type;
+		}
+	}
+
+	return len;
+}
+

--- a/src/grapheme.c
+++ b/src/grapheme.c
@@ -1,17 +1,15 @@
 #include <stdbit.h>
-#include <stddef.h>
 
 #include "grapheme.h"
 
-enum cpt_type get_cpt_type(const unsigned char c)
+enum utf8cpt_type get_utf8cpt_type(const char8_t c)
 {
 	// https://www.rfc-editor.org/rfc/rfc3629#section-3
 	if (stdc_bit_width_uc(c) < 8) {
 		return ASCII;
 	} else {
 		const unsigned char leading_ones = stdc_leading_ones_uc(c);
-		// Check if there's a zero after leading one(s)
-		if (stdc_first_leading_zero_uc(c) == (unsigned char)(leading_ones + 1)) {
+		if (stdc_first_leading_zero_uc(c) == leading_ones + 1) {
 			return leading_ones;
 		}
 	}
@@ -19,23 +17,22 @@ enum cpt_type get_cpt_type(const unsigned char c)
 	return INVALID;
 }
 
-int count_graphemes(const char* restrict str, const size_t str_len)
+int count_utf8_graphemes(const char* restrict str, const size_t str_len)
 {
-	unsigned int len = 0;
+	unsigned int count = 0;
 
-	enum cpt_type i_type = INVALID;
-	size_t i             = 0;
+	char i_type = INVALID;
+	size_t i    = 0;
 	while (i < str_len) {
-		i_type = get_cpt_type(str[i]);
-
+		i_type = get_utf8cpt_type(str[i]);
 		if (i_type == INVALID) {
 			return -1;
 		} else {
-			++len;
+			++count;
 			i += i_type;
 		}
 	}
 
-	return len;
+	return count;
 }
 

--- a/src/grapheme.h
+++ b/src/grapheme.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stddef.h>
+
+/**
+ * An enum which should be used to describe the role of a code point in a utf8 string.
+ */
+enum cpt_type : char {
+	INVALID = -1,
+	CONTINUATION,
+	ASCII,
+	DOUBLE_BEGIN,
+	TRIPLE_BEGIN,
+	QUADRUPLE_BEGIN,
+};
+
+/**
+ * Return the corresponding `enum cpt_type` for the given character.
+ * Defaults to `INVALID` if none of the conditions are met.
+ */
+enum cpt_type get_cpt_type(const unsigned char c);
+
+/**
+ * Count the number of graphemes with the given utf8 string.
+ * Returns -1 if the string is not valid utf8.
+ */
+int count_graphemes(const char* restrict str, const size_t str_len);
+

--- a/src/grapheme.h
+++ b/src/grapheme.h
@@ -1,28 +1,29 @@
 #pragma once
 
 #include <stddef.h>
+#include <uchar.h>
 
 /**
  * An enum which should be used to describe the role of a code point in a utf8 string.
  */
-enum cpt_type : char {
+enum utf8cpt_type : char {
 	INVALID = -1,
 	CONTINUATION,
 	ASCII,
-	DOUBLE_BEGIN,
-	TRIPLE_BEGIN,
-	QUADRUPLE_BEGIN,
+	TWO_WIDE_SEQ_START,
+	THREE_WIDE_SEQ_START,
+	FOUR_WIDE_SEQ_START,
 };
 
 /**
  * Return the corresponding `enum cpt_type` for the given character.
  * Defaults to `INVALID` if none of the conditions are met.
  */
-enum cpt_type get_cpt_type(const unsigned char c);
+enum utf8cpt_type get_utf8cpt_type(const char8_t);
 
 /**
  * Count the number of graphemes with the given utf8 string.
  * Returns -1 if the string is not valid utf8.
  */
-int count_graphemes(const char* restrict str, const size_t str_len);
+int count_utf8_graphemes(const char* restrict str, const size_t str_len);
 

--- a/src/test.c
+++ b/src/test.c
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
 	 */
 	const char* label              = (argc == 1 ? "Всем привет !" : argv[1]);
 	const size_t label_cpt_count   = strlen(label);
-	const int label_grapheme_count = count_graphemes(label, label_cpt_count);
+	const int label_grapheme_count = count_utf8_graphemes(label, label_cpt_count);
 	if (label_grapheme_count == -1) {
 		return -1;
 	}
@@ -87,12 +87,12 @@ int main(int argc, char** argv)
 	printf("\x1b[%hu;%huH", middle_line, left_gap_len + 1); // We go to y, x (line, column)
 
 
-	enum cpt_type cpt_i_type = INVALID;
+	enum utf8cpt_type cpt_i_type = INVALID;
 	uint8_t val              = 0;
 	size_t cpt_i = 0, grapheme_i = 0;
 	while (cpt_i < label_cpt_count) {
 		val = min(232 + ((float)grapheme_i / label_grapheme_count) * 24, 255); // 8 bit color ID
-		cpt_i_type = get_cpt_type(label[cpt_i]);
+		cpt_i_type = get_utf8cpt_type(label[cpt_i]);
 		if (cpt_i_type == INVALID) {
 			return -1;
 		} else {


### PR DESCRIPTION
Extract the logic in the test which allows the user to count and scan utf8 graphemes (single visible characters made of a variable amount of code points). The algorithm now refers to the definition of a utf8 code point directly using C23's new stdbit macros instead of doing sorcery with hexadecimal values.
See https://www.rfc-editor.org/rfc/rfc3629#section-3